### PR TITLE
ci: automated quick fix (add-package-lock)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elvatis_com/openclaw-homeassistant",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elvatis_com/openclaw-homeassistant",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",


### PR DESCRIPTION
Automated quick-fix PR created by Akido for CI failures. Action: add-package-lock. Please review and merge if acceptable.